### PR TITLE
fix: remove light mode css styles

### DIFF
--- a/packages/explorer/src/index.css
+++ b/packages/explorer/src/index.css
@@ -52,16 +52,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
Fixes #11 

There is technically no light color scheme. The only discernible change in light mode is the background. Removing this fixes the issue for light mode users.

![ScreenShot 2023-03-01 at 11 31 47](https://user-images.githubusercontent.com/708820/222217474-bbcce4a0-e24d-4a75-be33-b51849477d25.gif)