### PR TITLE
Add examples (config & figma link), fixed typo, tidied up organization of docs

### DIFF
--- a/packages/docs/config/introduction.md
+++ b/packages/docs/config/introduction.md
@@ -13,7 +13,6 @@ All options can also be passed as CLI options:
 npx @figus/cli --figma.token="token" figma.fileKey="zz" --figma.pageName="Icons" --output="src/components" 
 ```
 
-
 Figus have one config object [App Configs](./app-configs). 
 
 
@@ -40,4 +39,33 @@ import { defineConfig } from '@figus/cli'
 export default defineConfig({
   // ...
 })
+```
+
+## Example config 
+
+[CB Insights](https://www.cbinsights.com/) heavily customizes the config for their use case:
+
+```js
+import { defineConfig } from '@figus/cli';
+import dotenv from 'dotenv';
+import { pascalCase } from 'change-case';
+
+dotenv.config();
+
+export default defineConfig({
+  getFileName: (svgPathObj) => {
+    return `${pascalCase(svgPathObj.name)}Icon.tsx`;
+  },
+  output: 'packages/cbicons/src/components',
+  template: 'packages/cbicons/src/icon.mustache',
+  framework: 'react',
+  getComponentName: (name) => `${name}Icon`,
+  path: './packages/cbicons/src/assets',
+  figma: {
+    fileKey: 'qEm8vdvuoqzn51sx1JOngS',
+    // Create a .env file and put your token there
+    token: process.env.FIGMA_API_TOKEN,
+  },
+  iconify: false,
+});
 ```

--- a/packages/docs/guide/cli.md
+++ b/packages/docs/guide/cli.md
@@ -4,12 +4,13 @@ title: Features | CLI
 
 # CLI
 
+In a project where Figus is installed, you can use the `figus` binary in your npm scripts, or run it directly with `npx @figus/cli`.
+
 Figus comes with a built-in command line interface that accepts the same config as [App Config](../config/app-configs.md)
 All configuration can be passed as arguments, for example:
 ```bash
 npx @figus/cli --path './src/assets' --output './src/icons' --token "figma token" --page-name "figma page name" --file-key "figma file key"
 ```
-
 
 ## Commands
 

--- a/packages/docs/guide/figma.md
+++ b/packages/docs/guide/figma.md
@@ -1,4 +1,6 @@
-# Reserving Figma file-key and page name
+# Figma features
+
+## Retrieving Figma file-key and page name
 
 1. Open the page that contains the icons
 2. Open the Developer console (Cmd + Option + I / Ctrl + Shift + I)
@@ -10,4 +12,9 @@
 5. The page name will be available by writing `figma.currentPage.name`
 
 ![Page name](../assets/pageName.png)
+
+
+## Figma file examples
+
+- [CB Insights](https://www.cbinsights.com/) (cbicons): https://www.figma.com/file/qEm8vdvuoqzn51sx1JOngS/cbicons
 

--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -13,13 +13,13 @@ It supports React, React Material UI and Vue
 
 ```bash
 # with npm
-npm install -D @ficus/cli
+npm install -D @figus/cli
 
 # or with yarn
-yarn add -D @ficus/cli
+yarn add -D @figus/cli
 
 # or with pnpm
-pnpm add -D @ficus/cli
+pnpm add -D @figus/cli
 ```
 
 :::tip
@@ -36,9 +36,4 @@ See the list of config options in the [Config Reference](../config/app-configs.m
 
 ## Command Line Interface
 
-In a project where Figus is installed, you can use the `figus` binary in your npm scripts, or run it directly with `npx @figus/cli`.
-
 To download and generate icons, just run: `figus`
-
-
-## Examples

--- a/packages/explorer/src/index.css
+++ b/packages/explorer/src/index.css
@@ -52,16 +52,3 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/packages/explorer/src/index.css
+++ b/packages/explorer/src/index.css
@@ -52,3 +52,16 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}


### PR DESCRIPTION
Fixes #9 

- Fixed typos in commands (@ficus/cli → @figus/cli)
- Added example kitchen sink config in `config/introduction.md`
- Added a link to an example Figma file that works with the configuration
- Moved the note about being able to use the figus binary to `guide/cli.md`