### PR TITLE
bug fix: broken MIT license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ npx @figus/cli --token="figma token"
 
 ## License
 
-[MIT](../../LICENSE) License © 2021-Present [Omri Katz](https://github.com/omridevk)
+[MIT](https://github.com/figus-cli/figus/blob/main/LICENSE) License © 2021-Present [Omri Katz](https://github.com/omridevk)


### PR DESCRIPTION
I added a link to the MIT license on Github.